### PR TITLE
LIBFCREPO-892. Updated Dockerfiles with specific base image versions

### DIFF
--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8u265-jdk-buster
 
 ENV ACTIVEMQ_VERSION 5.16.0
 RUN curl -Ls http://archive.apache.org/dist/activemq/${ACTIVEMQ_VERSION}/apache-activemq-${ACTIVEMQ_VERSION}-bin.tar.gz \

--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -1,3 +1,10 @@
+# Dockerfile for the generating the ActiveMQ Docker image
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/fcrepo-activemq:<VERSION> -f Dockerfile .
+#
+# where <VERSION> is the Docker image version to create.
 FROM openjdk:8u265-jdk-buster
 
 ENV ACTIVEMQ_VERSION 5.16.0

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -1,3 +1,11 @@
+# Dockerfile for the generating the Fuseki image
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/fcrepo-fuseki:<VERSION> -f Dockerfile .
+#
+# where <VERSION> is the Docker image version to create.
+
 # generic Fuseki image
 FROM openjdk:8u265-jdk-buster AS fuseki
 

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -1,5 +1,5 @@
 # generic Fuseki image
-FROM openjdk:8 AS fuseki
+FROM openjdk:8u265-jdk-buster AS fuseki
 
 ENV FUSEKI_VERSION 2.3.1
 ENV FUSEKI_HOME /opt/apache-jena-fuseki-${FUSEKI_VERSION}

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,3 +1,10 @@
+# Dockerfile for the generating the Postgres image
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/fcrepo-postgres:<VERSION> -f Dockerfile .
+#
+# where <VERSION> is the Docker image version to create.
 FROM postgres:13.0-alpine
 ENV POSTGRES_PASSWORD=postgres
 

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:latest
+FROM postgres:13.0-alpine
 ENV POSTGRES_PASSWORD=postgres
 
 COPY fcrepo.sh /docker-entrypoint-initdb.d/

--- a/solr-fedora4/Dockerfile
+++ b/solr-fedora4/Dockerfile
@@ -1,3 +1,10 @@
+# Dockerfile for the generating the Solr image
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/fcrepo-solr-fedora4:<VERSION> -f Dockerfile .
+#
+# where <VERSION> is the Docker image version to create.
 FROM solr:6.6.6-slim
 USER root
 COPY --chown=solr:solr . /opt/solr/server/solr/mycores/fedora4

--- a/solr-fedora4/Dockerfile
+++ b/solr-fedora4/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:6
+FROM solr:6.6.6-slim
 USER root
 COPY --chown=solr:solr . /opt/solr/server/solr/mycores/fedora4
 RUN mkdir -p /var/opt/solr && chown solr:solr /var/opt/solr


### PR DESCRIPTION
Updated the Dockerfiles so that the base images had specific version
tags. This is intended to make it easier to reproduce a particular
Docker image by making it clear exactly which base images were used
to construct it.

https://issues.umd.edu/browse/LIBFCREPO-892