### PR TITLE
LIBFCREPO-892. Tweaked webapp Docker image name in umd-fcrepo.yml

### DIFF
--- a/umd-fcrepo.yml
+++ b/umd-fcrepo.yml
@@ -27,7 +27,7 @@ services:
     ports:
       - 3030:3030
   repository:
-    image: docker.lib.umd.edu/umd-fcrepo-webapp
+    image: docker.lib.umd.edu/fcrepo-webapp
     configs:
       - source: ip-mapping.properties
         target: /etc/fcrepo/ip-mapping.properties


### PR DESCRIPTION
Changed the webapp Docker image name from "umd-fcrepo-webapp" to
"fcrepo-webapp" to match the Docker image name in the sample build
command of the umd-fcrepo-webapp Dockerfile.

https://issues.umd.edu/browse/LIBFCREPO-892