### PR TITLE
LIBHYDRA-430. Updates to README.md and Docker Compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ These Docker images are defined in external repos, and must be built
 separately before deploying the umd-fcrepo-docker stack.
 
 * **docker.lib.umd.edu/fcrepo-messaging** (from [umd-fcrepo-messaging]):
-  
+
     ```bash
     cd ~/git
     git clone git@github.com:umd-lib/umd-fcrepo-messaging.git
@@ -17,14 +17,14 @@ separately before deploying the umd-fcrepo-docker stack.
     ```
 
 * **docker.lib.umd.edu/fcrepo-solr-fedora4** (from [umd-fcrepo-solr]):
-  
+
     ```bash
     cd ~/git
     git clone git@github.com:umd-lib/umd-fcrepo-solr.git
     cd umd-fcrepo-solr
     docker build -t docker.lib.umd.edu/fcrepo-solr-fedora4 .
     ```
-  
+
 * **docker.lib.umd.edu/fcrepo-webapp** (from [umd-fcrepo-webapp]):
 
     ```bash
@@ -94,6 +94,7 @@ To deploy the complete stack, including Archelon and Plastron, do the following:
         cd archelon
         docker build -t docker.lib.umd.edu/archelon .
         ```
+
     * **docker.lib.umd.edu/plastrond** (from [plastron]):
 
         ```bash
@@ -102,7 +103,9 @@ To deploy the complete stack, including Archelon and Plastron, do the following:
         cd plastron
         docker build -t docker.lib.umd.edu/plastrond .
         ```
+
 2. Export environment variables:
+
     ```bash
     export MODESHAPE_DB_PASSWORD=...  # default in the umd-fcrepo-docker stack is "fcrepo"
     export LDAP_BIND_PASSWORD=...     # see the SSDR "Identities" document for this
@@ -112,6 +115,7 @@ To deploy the complete stack, including Archelon and Plastron, do the following:
     export SECRET_KEY_BASE=...        # typically generated using "rails secret"
                                       # in the archelon repository
     ```
+
 3. Deploy the umd-fcrepo stack with additional config files:
 
     ```bash
@@ -162,14 +166,14 @@ docker service logs -f umd-fcrepo_mail
 * ActiveMQ admin console: <http://localhost:8161/admin>
 * Solr admin console: <http://localhost:8983/solr/#/>
 * Fuseki admin console: <http://localhost:3030/>
-* Fedora repository REST API: <http://localhost:8080/rest/>
-* Fedora repository login/user profile page: <http://localhost:8080/user/>
+* Fedora repository REST API: <http://localhost:8080/fcrepo/rest/>
+* Fedora repository login/user profile page: <http://localhost:8080/fcrepo/user/>
 * Archelon home page: <http://localhost:3000/> (if
   [deployed with Archelon])
 
 ### Database Ports
 
-The base stack starts 2 PostgreSQL containers, each containing a single 
+The base stack starts 2 PostgreSQL containers, each containing a single
 database:
 
 | Container Name | Port | Database Name     |
@@ -190,7 +194,7 @@ psql -U archelon -h localhost -p 5433 fcrepo_audit
 psql -U camel -h localhost -p 5433 fcrepo_audit
 ```
 
-If the stack is [deployed with Archelon], it will include an additional 
+If the stack is [deployed with Archelon], it will include an additional
 database:
 
 | Container Name | Port | Database Name     |

--- a/archelon.yml
+++ b/archelon.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - 5434:5432
   archelon-stomp-listener:
-    image: docker.lib.umd.edu/archelon
+    image: docker.lib.umd.edu/archelon:latest
     env_file:
       - ./archelon/archelon.env
     environment:
@@ -20,7 +20,7 @@ services:
       - SECRET_KEY_BASE
     command: [ "bundle", "exec", "rails", "stomp:listen" ]
   archelon:
-    image: docker.lib.umd.edu/archelon
+    image: docker.lib.umd.edu/archelon:latest
     ports:
       - 3000:3000
       - 2222:22

--- a/plastrond.yml
+++ b/plastrond.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   plastrond:
-    image: docker.lib.umd.edu/plastrond
+    image: docker.lib.umd.edu/plastrond:latest
     environment:
       - JWT_SECRET
     configs:

--- a/umd-fcrepo.yml
+++ b/umd-fcrepo.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - 5432:5432
   activemq:
-    image: docker.lib.umd.edu/fcrepo-messaging:1.0.1
+    image: docker.lib.umd.edu/fcrepo-messaging:latest
     volumes:
       - activemq-data:/var/opt/activemq
       - fixity-log-data:/var/log/fixity
@@ -48,19 +48,19 @@ services:
       - REPO_INTERNAL_URL=http://repository:8080/fcrepo/rest
       - SMTP_SERVER=mail:8025
   solr-fedora4:
-    image: docker.lib.umd.edu/fcrepo-solr-fedora4:1.0.1
+    image: docker.lib.umd.edu/fcrepo-solr-fedora4:latest
     volumes:
       - solr-fedora4-data:/var/opt/solr
     ports:
       - 8983:8983
   fuseki:
-    image: docker.lib.umd.edu/fcrepo-fuseki:1.0.0
+    image: docker.lib.umd.edu/fcrepo-fuseki:latest
     volumes:
       - fuseki-data:/var/opt/fuseki
     ports:
       - 3030:3030
   repository:
-    image: docker.lib.umd.edu/fcrepo-webapp:2.6.0
+    image: docker.lib.umd.edu/fcrepo-webapp:latest
     configs:
       - source: basic-auth.properties
         target: /etc/fcrepo/basic-auth.properties
@@ -96,7 +96,7 @@ services:
           - fcrepo-local
   mail:
     # debugging mail server for local development
-    image: docker.lib.umd.edu/fcrepo-mail:1.0.0
+    image: docker.lib.umd.edu/fcrepo-mail:latest
     ports:
       - 8025:8025
 


### PR DESCRIPTION
Updated the Fedora repository URLS in the README.md to take into
account the "/fcrepo" subpath, and fixed some whitespace issues.

Changed all the Docker images that are part of "umd-fcrepo-docker"
to use the "latest" version in the Docker Compose files, since this
is primarily intended for development.

https://issues.umd.edu/browse/LIBHYDRA-430