### PR TITLE
LIBFCREPO-1037. Added "REINDEXING" destination to support Solr reindex

### DIFF
--- a/plastron/plastron.yml
+++ b/plastron/plastron.yml
@@ -13,6 +13,7 @@ MESSAGE_BROKER:
     JOB_PROGRESS: /topic/plastron.jobs.progress
     JOB_STATUS: /queue/plastron.jobs.status
     SYNCHRONOUS_JOBS: /queue/plastron.jobs.synchronous
+    REINDEXING: /queue/reindex
 COMMANDS:
   EXPORT:
     SSH_PRIVATE_KEY: /etc/plastron/auth/archelon_id


### PR DESCRIPTION
Added "REINDEXING" to the DESTINATIONS stanza of "plastron/plastron.yml"
to enable Solr reindexing to be performed.

Solr reindexing is a workaround for the issue in LIBFCREPO-1027.

https://issues.umd.edu/browse/LIBFCREPO-1037